### PR TITLE
update biblatex style

### DIFF
--- a/common.tex
+++ b/common.tex
@@ -11,7 +11,7 @@
 \usepackage{textcase}
 \usepackage[titles]{tocloft}
 \usepackage[unicode=true]{hyperref}
-\usepackage[backend=biber,style=numeric]{biblatex}
+\usepackage[backend=biber,style=alphabetic]{biblatex}
 \usepackage{csquotes}
 
 \addbibresource{../biblatex/petersohn2011vergleich.bib}


### PR DESCRIPTION
the old style only printed [NUMBER] in a citation, the new style uses
the name of the author + the date it got published. you can check it on
page 8 of the pdf, 4.1 Scrum