### PR TITLE
fix broken latex layout

### DIFF
--- a/thesis-de/content-de.tex
+++ b/thesis-de/content-de.tex
@@ -527,21 +527,22 @@ Die festgehaltenen Anforderungen sind nun nach Relevanz absteigend aufgelistet:
 
 \subsubsection{Durchführung der Evaluierung}
 \label{subsubsec:api_durchfuehrung_der_evaluierung}
-Bei der Evaluierung der API Systeme wurden die in Punkt
-~\ref{subsubsec:api_vorbereitung_der_evaluierung} festgehaltenen Anforderungen
-der API als Leitlinie für die Durchführung verwendet. Als ersten Schritt wurde
-zunächst Recherche betrieben, damit das Projektteam einen allgemeinen Eindruck
-über die aktuelle Marktsitutation zu API Systemen erhält. Dabei wurden im
-Internet mehrere Blogs, Foren sowie Artikel von Fachzeitschriften gelesen.  Die
-dort angesprochenen API Systeme wurden anschließend mit den bereits definierten
-Anforderungen abgeglichen und aussortiert. Dabei stellten die Projektmitglieder
-fest, dass die meisten API Systeme von Cloudprovidern nur in bereits
-vorkonfigurierten Paketen mit einem monatlichen Festpreis angeboten werden.
-Beides ist ein absolutes Ausschluskriterium für den späteren Wirkbetrieb sowie
-Nutzung der Software. Ebenfalls wurde bei den vorkonfigurierten Paketen eine
-eigene Definition von Funktionen komplett verboten. Lediglich ein einzelner
-Cloudprovider hatte ein Angebotsmodel bei welchem die Kunden das betriebene
-API System in Hinischt der Funktionen modifizieren durfte.
+Bei der Evaluierung der API Systeme wurden die in
+Punkt~\ref{subsubsec:api_vorbereitung_der_evaluierung} festgehaltenen
+Anforderungen der API als Leitlinie für die Durchführung verwendet. Als ersten
+Schritt wurde zunächst Recherche betrieben, damit das Projektteam einen
+allgemeinen Eindruck über die aktuelle Marktsitutation zu API Systemen erhält.
+Dabei wurden im Internet mehrere Blogs, Foren sowie Artikel von
+Fachzeitschriften gelesen.  Die dort angesprochenen API Systeme wurden
+anschließend mit den bereits definierten Anforderungen abgeglichen und
+aussortiert. Dabei stellten die Projektmitglieder fest, dass die meisten API
+Systeme von Cloudprovidern nur in bereits vorkonfigurierten Paketen mit einem
+monatlichen Festpreis angeboten werden.  Beides ist ein absolutes
+Ausschluskriterium für den späteren Wirkbetrieb sowie Nutzung der Software.
+Ebenfalls wurde bei den vorkonfigurierten Paketen eine eigene Definition von
+Funktionen komplett verboten. Lediglich ein einzelner Cloudprovider hatte ein
+Angebotsmodel bei welchem die Kunden das betriebene API System in Hinischt der
+Funktionen modifizieren durfte.
 
 Aufgrund diesen Erkentnissen hat sich das Projektteam während der Evaluierung
 für ein API System mit dem Namen ``Swagger'' entschieden. Es ist aktuell das


### PR DESCRIPTION
a ~ always has to connect to the word left to it. No newline/whitespace
allowed